### PR TITLE
Allow to view unpublished page or go back

### DIFF
--- a/djangocms_concurrent_users/static/css/concurrent_users.css
+++ b/djangocms_concurrent_users/static/css/concurrent_users.css
@@ -1,20 +1,3 @@
-/*.concurrentWarning {*/
-    /*font-family: Helvetica, Arial, sans-serif !important;*/
-    /*text-align:center !important;*/
-    /*position: fixed !important;*/
-    /*color: white !important;*/
-    /*font-size: large !important;*/
-    /*top: 100px !important;*/
-    /*width: 100% !important;*/
-    /*z-index: 10001 !important;*/
-    /*background-color: rgba(255,0,0,0.9) !important;*/
-    /*padding: 15px 5px;*/
-/*}*/
-/*.concurrentWarning a {*/
-    /*color: white;*/
-    /*font-weight: bold;*/
-    /*text-decoration: underline;*/
-/*}*/
 .concurrentWarning {
     display: none;
     position: absolute !important;
@@ -24,17 +7,13 @@
     width: auto;
     max-width: 100% !important;
     z-index: 10001 !important;
-    /*padding: 15px 5px !important;*/
     padding: 20px 15px 15px;
-    box-shadow: #eee 0px 2px 5px !important;
+    box-shadow: #eee 0 2px 5px !important;
     background: #fff !important;
     font-family: Helvetica, Arial, sans-serif;
     text-align:center !important;
     color: black !important;
     font-size: large !important;
-}
-.concurrentWarning .cms-modal-item-buttons {
-    /*padding-right: 15px;*/
 }
 .concurrentWarning .concurrentWarningButtonPublishedPage {
     margin-left: 5px;

--- a/djangocms_concurrent_users/static/css/concurrent_users.css
+++ b/djangocms_concurrent_users/static/css/concurrent_users.css
@@ -1,13 +1,41 @@
+/*.concurrentWarning {*/
+    /*font-family: Helvetica, Arial, sans-serif !important;*/
+    /*text-align:center !important;*/
+    /*position: fixed !important;*/
+    /*color: white !important;*/
+    /*font-size: large !important;*/
+    /*top: 100px !important;*/
+    /*width: 100% !important;*/
+    /*z-index: 10001 !important;*/
+    /*background-color: rgba(255,0,0,0.9) !important;*/
+    /*padding: 15px 5px;*/
+/*}*/
+/*.concurrentWarning a {*/
+    /*color: white;*/
+    /*font-weight: bold;*/
+    /*text-decoration: underline;*/
+/*}*/
 .concurrentWarning {
-    font-family: Helvetica, Arial, sans-serif !important;
-    text-align:center !important;
-    line-height: 50px !important;
-    position: fixed !important;
-    color: white !important;
-    font-size: large !important;
-    top: 100px !important;
-    width: 100% !important;
-    height: 50px !important;
+    display: none;
+    position: absolute !important;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: auto;
+    max-width: 100% !important;
     z-index: 10001 !important;
-    background-color: rgba(255,0,0,0.9) !important;
+    /*padding: 15px 5px !important;*/
+    padding: 20px 15px 15px;
+    box-shadow: #eee 0px 2px 5px !important;
+    background: #fff !important;
+    font-family: Helvetica, Arial, sans-serif;
+    text-align:center !important;
+    color: black !important;
+    font-size: large !important;
+}
+.concurrentWarning .cms-modal-item-buttons {
+    /*padding-right: 15px;*/
+}
+.concurrentWarning .concurrentWarningButtonPublishedPage {
+    margin-left: 5px;
 }

--- a/djangocms_concurrent_users/static/js/concurrent_users.js
+++ b/djangocms_concurrent_users/static/js/concurrent_users.js
@@ -17,17 +17,17 @@ var ConcurrentUsers = {
         $('.js-preventClickOverlay').hide();
         $('.js-concurrentWarning').hide();
     },
-    showMessage: function(data) {
+    showMessage: function (data) {
         // var message_bar = '<div class="js-concurrentWarning concurrentWarning">' + data.message + '</div>'
         // $('body, .cms-structure').append(message_bar);
         $('.js-concurrentWarningMessage').text(data.message);
-        $('.js-concurrentWarningButtonPublishedPage').attr('href', (data.buttons.published_page.link));
-        $('.js-concurrentWarningButtonPublishedPage').text(data.buttons.published_page.link_text);
-        $('.js-concurrentWarningButtonBack').attr('href', (data.buttons.back.link));
+        $('.js-concurrentWarningButtonPublishedPage').attr('href', (data.buttons.published_page.link))
+                                                     .text(data.buttons.published_page.link_text);
         $('.js-concurrentWarningButtonBack').text(data.buttons.back.link_text);
-        $('.js-concurrentWarning').show();
-        if ($('.js-concurrentWarning').length < 2) {
-            $('body, .cms-structure').append($('.js-concurrentWarning'));
+        var $concurrentWarning = $('.js-concurrentWarning');
+        $concurrentWarning.show();
+        if ($concurrentWarning.length < 2) {
+            $('body, .cms-structure').append($concurrentWarning);
         }
     },
     updateIndicator: function updateIndicator() {
@@ -66,11 +66,11 @@ var ConcurrentUsers = {
                         ConcurrentUsers.updateIndicator();
                     }
                     else {
-                        if(ConcurrentUsers.wasBlocked){
+                        if (ConcurrentUsers.wasBlocked) {
                             // it this user was blocked, we need to reload the changed content
                             location.reload();
                         }
-                        else{
+                        else {
                             ConcurrentUsers.updateIndicator();
                             ConcurrentUsers.hideOverlay();
                         }

--- a/djangocms_concurrent_users/static/js/concurrent_users.js
+++ b/djangocms_concurrent_users/static/js/concurrent_users.js
@@ -4,8 +4,9 @@ var ConcurrentUsers = {
         var ele = $('.js-concurrentExclude');
         $('.js-preventClickOverlay').css({
             position: 'fixed',
-            top: ele.offset().top + 'px',
-            left: ele.offset().left + 'px',
+            top: 0,
+            // top: ele.offset().top + 'px',
+            // left: ele.offset().left + 'px',
             width: '100%',
             height: '100%',
             backgroundColor: 'rgba(0,0,0,0.5)',
@@ -14,7 +15,20 @@ var ConcurrentUsers = {
     },
     hideOverlay: function hideOverlay() {
         $('.js-preventClickOverlay').hide();
-        $('.js-concurrentWarning').remove();
+        $('.js-concurrentWarning').hide();
+    },
+    showMessage: function(data) {
+        // var message_bar = '<div class="js-concurrentWarning concurrentWarning">' + data.message + '</div>'
+        // $('body, .cms-structure').append(message_bar);
+        $('.js-concurrentWarningMessage').text(data.message);
+        $('.js-concurrentWarningButtonPublishedPage').attr('href', (data.buttons.published_page.link));
+        $('.js-concurrentWarningButtonPublishedPage').text(data.buttons.published_page.link_text);
+        $('.js-concurrentWarningButtonBack').attr('href', (data.buttons.back.link));
+        $('.js-concurrentWarningButtonBack').text(data.buttons.back.link_text);
+        $('.js-concurrentWarning').show();
+        if ($('.js-concurrentWarning').length < 2) {
+            $('body, .cms-structure').append($('.js-concurrentWarning'));
+        }
     },
     updateIndicator: function updateIndicator() {
         $.ajax({
@@ -44,14 +58,7 @@ var ConcurrentUsers = {
                     }
                     // display the overlay
                     ConcurrentUsers.showOverlay();
-                    // display the message coming from the server
-                    if (!$('.js-concurrentWarning').length) {
-                        message_bar = '<div class="js-concurrentWarning concurrentWarning">' + data.message + '</div>'
-                        $('body, .cms-structure').append(message_bar);
-                    }
-                    else{
-                        $('.js-concurrentWarning').html(data.message);
-                    }
+                    ConcurrentUsers.showMessage(data);
                     ConcurrentUsers.wasBlocked = true;
                 }
                 else {
@@ -70,9 +77,9 @@ var ConcurrentUsers = {
 
                     }
                 }
-            },
+            }
         });
-    },
+    }
 };
 
 document.addEventListener('DOMContentLoaded', ConcurrentUsers.updateStatus, false);

--- a/djangocms_concurrent_users/static/js/concurrent_users.js
+++ b/djangocms_concurrent_users/static/js/concurrent_users.js
@@ -1,12 +1,9 @@
 var ConcurrentUsers = {
     wasBlocked: false,
     showOverlay: function setOverlay() {
-        var ele = $('.js-concurrentExclude');
         $('.js-preventClickOverlay').css({
             position: 'fixed',
             top: 0,
-            // top: ele.offset().top + 'px',
-            // left: ele.offset().left + 'px',
             width: '100%',
             height: '100%',
             backgroundColor: 'rgba(0,0,0,0.5)',
@@ -18,8 +15,6 @@ var ConcurrentUsers = {
         $('.js-concurrentWarning').hide();
     },
     showMessage: function (data) {
-        // var message_bar = '<div class="js-concurrentWarning concurrentWarning">' + data.message + '</div>'
-        // $('body, .cms-structure').append(message_bar);
         $('.js-concurrentWarningMessage').text(data.message);
         $('.js-concurrentWarningButtonPublishedPage').attr('href', (data.buttons.published_page.link))
                                                      .text(data.buttons.published_page.link_text);

--- a/djangocms_concurrent_users/templates/djangocms_concurrent_users/concurrency_button.html
+++ b/djangocms_concurrent_users/templates/djangocms_concurrent_users/concurrency_button.html
@@ -19,3 +19,11 @@
 
 <link rel="stylesheet" href="{% static 'css/concurrent_users.css' %}">
 
+<div class="cms js-concurrentWarning concurrentWarning">
+    <div class="js-concurrentWarningMessage"></div>
+    <br>
+    <div class="cms-modal-item-buttons">
+        <a href="javascript:window.history.back();" type="button" class="cms-btn js-concurrentWarningButtonBack"></a>
+        <a href="" type="button" class="cms-btn cms-btn-action js-concurrentWarningButtonPublishedPage concurrentWarningButtonPublishedPage"></a>
+    </div>
+</div>

--- a/djangocms_concurrent_users/views.py
+++ b/djangocms_concurrent_users/views.py
@@ -50,7 +50,6 @@ class PageIndicatorStatusView(View):
                     'link_text': _('View Published Page'),
                 },
                 'back': {
-                    'link': '',
                     'link_text': _('Back'),
                 }
             }


### PR DESCRIPTION
- Redesign the concurrency error modal
- Add two action-buttons to the error modal: 'Back' and 'View Published Page'

This way the user is not "trapped" anymore in the error modal, but has a great way to get back to safety again :sunglasses:

![concurrent-buttons](https://cloud.githubusercontent.com/assets/3121306/25489455/2fe3d778-2b6a-11e7-9b7c-91220d584034.png)
 
 
 
ToDo:
- [x] Remove commented code